### PR TITLE
Add RBAC example with sa and role

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We need to keep track of supported and unsupported test cases.
   - Basic app example -  ```nginx```
   - Pod - ```pod```
   - Image Stream - ```mysql-centos7-is```
+  - RBAC - ```basic-sa-with-role```
 
 * Tests cases that are expected to fail:
 

--- a/basic-sa-with-role.yml
+++ b/basic-sa-with-role.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  vars_prompt:
+    - name: user
+      prompt: "Cluster login"
+      private: no
+  roles:
+  - login_ocp
+  - rbac/basic_sa_with_role

--- a/roles/rbac/basic_sa_with_role/files/basic-sa-role-template.yml
+++ b/roles/rbac/basic_sa_with_role/files/basic-sa-role-template.yml
@@ -1,0 +1,45 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: basic-sa-role
+  labels:
+    app: basic-sa-role
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: basic-sa
+  namespace: basic-sa-role
+  labels:
+    app: basic-sa-role
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: basic-role
+  namespace: basic-sa-role
+  labels:
+    app: basic-sa-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: basic-role-binding
+  namespace: basic-sa-role
+  labels:
+    app: basic-sa-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: basic-role
+subjects:
+- kind: ServiceAccount
+  name: basic-sa

--- a/roles/rbac/basic_sa_with_role/files/create-backup-sa-role.yml
+++ b/roles/rbac/basic_sa_with_role/files/create-backup-sa-role.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: ark.heptio.com/v1
+kind: Backup
+metadata:
+  name: sa-role-backup
+  namespace: heptio-ark
+spec:
+  labelSelector:
+    matchLabels:
+      app: basic-sa-role
+  storageLocation: default
+  ttl: 720h0m0s
+  includedNamespaces:
+  - '*'

--- a/roles/rbac/basic_sa_with_role/files/create-restore-sa-role.yml
+++ b/roles/rbac/basic_sa_with_role/files/create-restore-sa-role.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: ark.heptio.com/v1
+kind: Restore
+metadata:
+  name: sa-role-restore
+  namespace: heptio-ark
+spec:
+  backupName: sa-role-backup
+  excludedResources:
+  - node
+  - events
+  - events.events.k8s.io
+  - backups.ark.heptio.com
+  - restores.ark.heptio.com
+  includedNamespaces:
+  - '*'

--- a/roles/rbac/basic_sa_with_role/tasks/main.yml
+++ b/roles/rbac/basic_sa_with_role/tasks/main.yml
@@ -1,0 +1,100 @@
+- name: Create service account, role and role binding
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'basic-sa-role-template.yml')}}"
+
+# Create a backup
+- name: Create velero backup of service account
+  k8s:
+    state : present
+    definition: "{{ lookup('file', 'create-backup-sa-role.yml')}}"
+
+- name: Wait 1 minute for backup to complete
+  k8s_facts:
+    api_version: ark.heptio.com/v1
+    kind: Backup
+    namespace: heptio-ark
+    name: sa-role-backup
+  register: backup
+  until: backup
+         and (backup.resources | length > 0)
+         and (backup.resources[0].get("status", {}).get("phase", 0) == "Completed")
+  retries: 10
+  delay: 5
+
+# Simulate DR and restore
+- name: Delete service account
+  k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: basic-sa-role
+
+- name: Wait 2 minutes for namespace to be deleted
+  k8s_facts:
+    api_version: v1
+    kind: Namespace
+    namespace: basic-sa-role
+    name: basic-sa-role
+  register: ns
+  until: ns.resources | length == 0
+  retries: 10
+  delay: 5
+
+- name: Create velero restore of service account
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'create-restore-sa-role.yml')}}"
+
+- name: Wait 3 minutes for restore to finish
+  k8s_facts:
+    api_version: v1
+    kind: Restore
+    namespace: heptio-ark
+    name: sa-role-restore
+  register: restore
+  until: restore
+         and (restore.resources | length > 0)
+         and (restore.resources[0].get("status", {}).get("phase", 0) == "Completed")
+  retries: 20
+  delay: 10
+
+- name: Wait 2 minutes for service account to appear
+  k8s_facts:
+    api_version: v1
+    kind: ServiceAccount
+    namespace: basic-sa-role
+    name: basic-sa
+  register: service_account
+  until: service_account and (service_account.resources | length > 0)
+  retries: 10
+  delay: 10
+
+- name: Wait 2 minutes for role to appear
+  k8s_facts:
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: Role
+    namespace: basic-sa-role
+    name: basic-role
+  register: role
+  until: role and (role.resources | length > 0)
+  retries: 10
+  delay: 10
+
+- name: Wait 2 minutes for role binding to appear
+  k8s_facts:
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: RoleBinding
+    namespace: basic-sa-role
+    name: basic-role-binding
+  register: role_binding
+  until: role_binding and (role_binding.resources | length > 0)
+  retries: 10
+  delay: 10
+
+- name: Delete velero restore (workaround to use common name for restore)
+  k8s:
+    state: absent
+    definition: "{{ lookup('file', 'create-restore-sa-role.yml')}}"


### PR DESCRIPTION
This PR adds RBAC example with service account and role.
I'm not sure about service account's secrets, show they be same before backup and after restore? @jwmatthews 