### PR TITLE
Make backup and restore optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ python: "2.7"
 services:
   - docker
 
-env:
-  - TRAVIS=true
-
 before_install:
   - sudo apt-get update -qq
   - sudo sed -i "s/\DOCKER_OPTS=\"/DOCKER_OPTS=\"--insecure-registry=172.30.0.0\/16 /g" /etc/default/docker
@@ -24,7 +21,7 @@ before_script:
   - bash ci/prepare.sh
 
 script:
-  - ansible-playbook all.yml -vvv
+  - ansible-playbook all.yml -e with_backup=true
 
 notifications:
  email:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Set cluster password to env variable like this:
 
 Run ```ansible-playbook cake-php.yml``` to deploy, backup and restore a sample app.
 
+It's also possible to optionally run backup/restore: ```ansible-playbook cake-php.yml -e with_backup=false -e with_restore=false```
+
 # Test cases info
 
 We need to keep track of supported and unsupported test cases.

--- a/all.yml
+++ b/all.yml
@@ -1,7 +1,8 @@
 - hosts: localhost
   vars:
     state: present
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: false
+    with_restore: false
   roles:
     - rbac/basic_sa_with_role
     - pvc/mysql_pvc

--- a/basic-sa-with-role.yml
+++ b/basic-sa-with-role.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars: 
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/cakephp.yml
+++ b/cakephp.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/crd.yml
+++ b/crd.yml
@@ -1,4 +1,7 @@
 - hosts: localhost
+  vars:
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/mysql-centos7-is.yml
+++ b/mysql-centos7-is.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/mysql-pvc.yml
+++ b/mysql-pvc.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/nginx.yml
+++ b/nginx.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
     state: present
   vars_prompt:
     - name: user

--- a/pod.yml
+++ b/pod.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"

--- a/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
+++ b/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
@@ -18,6 +18,7 @@
   delay: 10
 
 - name: Create backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -27,7 +28,7 @@
         backup_label: nginx
 
 - name: Restore resources
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/crd/simple_crd/tasks/main.yml
+++ b/roles/crd/simple_crd/tasks/main.yml
@@ -32,6 +32,7 @@
             replicas: 1
 
 - name: Create backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -41,7 +42,7 @@
         backup_label: crd-example
 
 - name: Restore service
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/deployment/nginx_deployment/tasks/main.yml
+++ b/roles/deployment/nginx_deployment/tasks/main.yml
@@ -18,6 +18,7 @@
       delay: 10
 
 - name: Create backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -27,7 +28,7 @@
         backup_label: nginx-deployment
 
 - name: Restore service
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/imagestream/mysql_centos7/tasks/main.yml
+++ b/roles/imagestream/mysql_centos7/tasks/main.yml
@@ -16,6 +16,7 @@
       delay: 10
 
 - name: Create backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -25,7 +26,7 @@
         backup_label: mysql
 
 - name: Restore resource
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/pod/hello-pod/tasks/main.yml
+++ b/roles/pod/hello-pod/tasks/main.yml
@@ -42,6 +42,7 @@
       delay: 10
 
 - name: Create a backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -51,7 +52,7 @@
         backup_label: hello-openshift
 
 - name: Restore pod
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/pvc/mysql_pvc/tasks/main.yml
+++ b/roles/pvc/mysql_pvc/tasks/main.yml
@@ -26,6 +26,7 @@
       delay: 15
 
 - name: Create a backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -34,9 +35,8 @@
         backup_name:  mysql-persistent-backup
         backup_label: mysql
 
-# Restore part
 - name: Restore service
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/rbac/basic_sa_with_role/tasks/main.yml
+++ b/roles/rbac/basic_sa_with_role/tasks/main.yml
@@ -6,6 +6,7 @@
         definition: "{{ lookup('file', 'basic-sa-role-template.yml')}}"
 
 - name: Create backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -15,7 +16,7 @@
         backup_label: basic-sa-role
 
 - name: Restore service account
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/route/route_example/tasks/main.yml
+++ b/roles/route/route_example/tasks/main.yml
@@ -18,6 +18,7 @@
       delay: 3
 
 - name: Create route and backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -26,9 +27,8 @@
         backup_name: route-backup
         backup_label: route
 
-# Restore part
 - name: Restore route
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/s2i/cakephp_backup_restore/tasks/main.yml
+++ b/roles/s2i/cakephp_backup_restore/tasks/main.yml
@@ -17,6 +17,7 @@
       delay: 30
 
 - name: Create a backup of cakephp
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -26,7 +27,7 @@
         backup_label: hello-openshift
 
 - name: Restore service
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/roles/service/basic-service/tasks/main.yml
+++ b/roles/service/basic-service/tasks/main.yml
@@ -30,6 +30,7 @@
       delay: 5
 
 - name: Create a backup
+  when: with_backup
   block:
     - name: Create backup
       include_role:
@@ -39,7 +40,7 @@
         backup_label: hello-openshift
 
 - name: Restore service
-  when: not travisCI
+  when: with_restore
   block:
     - name: Start restoring 
       include_role:

--- a/route.yml
+++ b/route.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
   - name: user
     prompt: "Cluster login"

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
-    travisCI: "{{ lookup('ENV', 'TRAVIS') }}"
+    with_backup: true
+    with_restore: true
   vars_prompt:
     - name: user
       prompt: "Cluster login"


### PR DESCRIPTION
This PR makes backup and restore optional. Now the playbooks could be run like this:
`ansible-playbook all.yml -e with_backup=true -e with_restore=true`

For `all.yml` the default is no backup and restore, for every other playbook backup and restore is default. I will also update readme.