### PR TITLE
Pass namespaces for deletion as list

### DIFF
--- a/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
+++ b/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
@@ -36,7 +36,8 @@
       vars:
         restore_name: nginx-restore
         backup_name: nginx-backup
-        namespace_to_delete: nginx-example
+        namespaces_to_delete:
+          - nginx-example
 
     - name: Wait for nginx deployment
       k8s_facts:

--- a/roles/crd/simple_crd/tasks/main.yml
+++ b/roles/crd/simple_crd/tasks/main.yml
@@ -50,7 +50,8 @@
       vars:
         restore_name: crd-restore
         backup_name: crd-backup
-        namespace_to_delete: crd-example
+        namespaces_to_delete:
+          - crd-example
 
     - name: Wait 2 minutes for CRD to appear
       k8s_facts:

--- a/roles/deployment/nginx_deployment/tasks/main.yml
+++ b/roles/deployment/nginx_deployment/tasks/main.yml
@@ -36,7 +36,8 @@
       vars:
         restore_name: nginx-deployment-restore
         backup_name: nginx-deployment-backup
-        namespace_to_delete: nginx-deployment
+        namespaces_to_delete:
+          - nginx-deployment
 
     - name: Check for deployment presence
       k8s_facts:

--- a/roles/imagestream/mysql_centos7/tasks/main.yml
+++ b/roles/imagestream/mysql_centos7/tasks/main.yml
@@ -34,7 +34,8 @@
       vars:
         restore_name: mysql-centos7-imagestream-restore
         backup_name: mysql-centos7-imagestream-backup
-        namespace_to_delete: mysql-centos7-imagestream
+        namespaces_to_delete: 
+          - mysql-centos7-imagestream
 
     - name: Wait for image stream to appear
       k8s_facts:

--- a/roles/pod/hello-pod/tasks/main.yml
+++ b/roles/pod/hello-pod/tasks/main.yml
@@ -60,7 +60,8 @@
       vars:
         restore_name: hellopod-restore
         backup_name: hellopod-backup
-        namespace_to_delete: hello-pod
+        namespaces_to_delete:
+          - hello-pod
 
     - name: Wait for pod to run
       k8s_facts:

--- a/roles/pvc/mysql_pvc/tasks/main.yml
+++ b/roles/pvc/mysql_pvc/tasks/main.yml
@@ -44,7 +44,8 @@
       vars:
         restore_name: mysql-persistent-restore
         backup_name: mysql-persistent-backup
-        namespace_to_delete: mysql-persistent
+        namespaces_to_delete:
+          - mysql-persistent
 
     - name: Wait for mysql with pvc deployment
       k8s_facts:

--- a/roles/rbac/basic_sa_with_role/tasks/main.yml
+++ b/roles/rbac/basic_sa_with_role/tasks/main.yml
@@ -24,7 +24,8 @@
       vars:
         restore_name: sa-role-restore
         backup_name: sa-role-backup
-        namespace_to_delete: basic-sa-role
+        namespaces_to_delete:
+          - basic-sa-role
 
     - name: Wait 2 minutes for service account to appear
       k8s_facts:

--- a/roles/restore/tasks/main.yml
+++ b/roles/restore/tasks/main.yml
@@ -5,17 +5,19 @@
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: "{{ namespace_to_delete }}"
+        name: "{{ item }}"
+  loop: "{{ namespaces_to_delete }}"
 
 - name: Wait 2 minutes for namespace to be deleted
   k8s_facts:
     kind: Namespace
     api_version: v1
-    name: "{{ namespace_to_delete }}"
+    name: "{{ item }}"
   register: ns
   until: not ns.get("resources", [""])
   retries: 20
   delay: 30
+  loop: "{{ namespaces_to_delete }}"
 
 - name: Create ark restore of resource
   k8s:

--- a/roles/route/route_example/tasks/main.yml
+++ b/roles/route/route_example/tasks/main.yml
@@ -36,7 +36,8 @@
       vars:
         restore_name: route-restore
         backup_name: route-backup
-        namespace_to_delete: route-example
+        namespaces_to_delete:
+          - route-example
 
     - name: Checking the route after restore
       k8s_facts:

--- a/roles/s2i/cakephp_backup_restore/tasks/main.yml
+++ b/roles/s2i/cakephp_backup_restore/tasks/main.yml
@@ -35,7 +35,8 @@
       vars:
         restore_name: cakephp-restore
         backup_name: cakephp-backup
-        namespace_to_delete: cakephp-example
+        namespaces_to_delete:
+          - cakephp-example
 
     # Check every restored resource
     - name: Wait for cakephp deployment

--- a/roles/service/basic-service/tasks/main.yml
+++ b/roles/service/basic-service/tasks/main.yml
@@ -48,7 +48,8 @@
       vars:
         restore_name: service-basic-restore
         backup_name: service-basic-backup
-        namespace_to_delete: service-example
+        namespaces_to_delete:
+          - service-example
 
     - name: Wait 2 minutes for service to appear
       k8s_facts:


### PR DESCRIPTION
We need to pass namespaces for deletion as a list, because soon we are going to have examples that involve more than 1 namespace, like network policy. Now the role will iterate through namespaces and delete them.