### PR TITLE
Move resource presence checks to separate task

### DIFF
--- a/roles/basic_app_examples/nginx_backup_restore/tasks/check.yml
+++ b/roles/basic_app_examples/nginx_backup_restore/tasks/check.yml
@@ -1,0 +1,11 @@
+- name: Wait 2 minutes for nginx deployment
+  k8s_facts:
+    kind: Deployment
+    api_version: apps/v1
+    namespace: nginx-example
+    label_selectors: "app=nginx"
+  register: deploy
+  until:  deploy.get("resources", [])
+          and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
+  retries: 10
+  delay: 10

--- a/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
+++ b/roles/basic_app_examples/nginx_backup_restore/tasks/main.yml
@@ -5,17 +5,8 @@
     state: "{{ state }}"
     definition: "{{ lookup('file', 'base.yml')}}"
 
-- name: Wait 2 minutes for nginx deployment
-  k8s_facts:
-    kind: Deployment
-    api_version: apps/v1
-    namespace: nginx-example
-    label_selectors: "app=nginx"
-  register: deploy
-  until:  deploy.get("resources", [])
-          and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-  retries: 10
-  delay: 10
+- name: Check resource presence
+  include: check.yml
 
 - name: Create backup
   when: with_backup
@@ -31,14 +22,5 @@
       include_role:
         name: restore
 
-    - name: Wait for nginx deployment
-      k8s_facts:
-        kind: Deployment
-        api_version: apps/v1
-        namespace: nginx-example
-        label_selectors: app=nginx
-      register: deploy
-      until:  deploy.get("resources", [])
-              and deploy.resources[0].get("spec", {}).replicas == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml

--- a/roles/crd/simple_crd/tasks/check.yml
+++ b/roles/crd/simple_crd/tasks/check.yml
@@ -1,0 +1,10 @@
+- name: Wait for CRD creation
+  k8s_facts:
+    api_version: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    name: crexamples.samplecontroller.k8s.io
+    namespace: crd-example
+  register: crd
+  until:  crd.get("resources", [])
+  retries: 10
+  delay: 5

--- a/roles/crd/simple_crd/tasks/main.yml
+++ b/roles/crd/simple_crd/tasks/main.yml
@@ -5,16 +5,8 @@
         state: present
         definition: "{{ lookup('file', 'crd-template.yml')}}"
 
-    - name: Wait for CRD creation
-      k8s_facts:
-        api_version: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        name: crexamples.samplecontroller.k8s.io
-        namespace: crd-example
-      register: crd
-      until:  crd.get("resources", [])
-      retries: 10
-      delay: 5
+    - name: Check resource presence
+      include: check.yml
 
     - name: Create custom resource
       k8s:
@@ -45,16 +37,8 @@
       include_role:
         name: restore
 
-    - name: Wait 2 minutes for CRD to appear
-      k8s_facts:
-        api_version: apiextensions.k8s.io/v1beta1
-        kind: CustomResourceDefinition
-        namespace: crd-example
-        name: crexamples.samplecontroller.k8s.io
-      register: crd
-      until: crd and (crd.resources | length > 0)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml
 
     - name: Wait 2 minutes for custom resource to appear
       k8s_facts:

--- a/roles/deployment/nginx_deployment/tasks/check.yml
+++ b/roles/deployment/nginx_deployment/tasks/check.yml
@@ -1,0 +1,11 @@
+- name: Check for deployment presence
+  k8s_facts:
+    kind: Deployment
+    api_version: apps/v1beta1
+    namespace: nginx-deployment
+    label_selectors: "app=nginx-deployment"
+  register: deploy
+  until:  deploy.get("resources", [])
+          and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
+  retries: 10
+  delay: 10

--- a/roles/deployment/nginx_deployment/tasks/main.yml
+++ b/roles/deployment/nginx_deployment/tasks/main.yml
@@ -5,17 +5,8 @@
         state: present
         definition: "{{ lookup('file', 'nginx-deployment-template.yml')}}"
 
-    - name: Check for deployment presence
-      k8s_facts:
-        kind: Deployment
-        api_version: apps/v1
-        namespace: nginx-deployment
-        label_selectors: "app=nginx-deployment"
-      register: deploy
-      until:  deploy.get("resources", [])
-              and deploy.resources[0].get("status", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create backup
   when: with_backup
@@ -31,14 +22,5 @@
       include_role:
         name: restore
 
-    - name: Check for deployment presence
-      k8s_facts:
-        kind: Deployment
-        api_version: apps/v1beta1
-        namespace: nginx-deployment
-        label_selectors: "app=nginx-deployment"
-      register: deploy
-      until:  deploy.get("resources", [])
-              and deploy.resources[0].get("spec", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", 0)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml

--- a/roles/imagestream/mysql_centos7/tasks/check.yml
+++ b/roles/imagestream/mysql_centos7/tasks/check.yml
@@ -1,0 +1,9 @@
+- name: Wait for image stream to appear
+  k8s_facts:
+    kind: ImageStream
+    namespace: mysql-centos7-imagestream
+    name: mysql
+  register: imagestream
+  until: imagestream.get("resources", [])
+  retries: 20
+  delay: 10

--- a/roles/imagestream/mysql_centos7/tasks/main.yml
+++ b/roles/imagestream/mysql_centos7/tasks/main.yml
@@ -5,15 +5,8 @@
         state: present
         definition: "{{ lookup('file', 'mysql-centos7-is-example.yml')}}"
 
-    - name: Wait for image stream to appear
-      k8s_facts:
-        kind: ImageStream
-        namespace: mysql-centos7-imagestream
-        name: mysql
-      register: imagestream
-      until: imagestream.get("resources", [])
-      retries: 20
-      delay: 10
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create backup
   when: with_backup
@@ -29,12 +22,5 @@
       include_role:
         name: restore
 
-    - name: Wait for image stream to appear
-      k8s_facts:
-        kind: ImageStream
-        namespace: mysql-centos7-imagestream
-        name: mysql
-      register: imagestream
-      until: imagestream.get("resources", [])
-      retries: 20
-      delay: 10
+    - name: Check resource presence
+      include: check.yml

--- a/roles/pipeline/pipeline_example/tasks/check.yml
+++ b/roles/pipeline/pipeline_example/tasks/check.yml
@@ -1,0 +1,12 @@
+- name: Checking the build is created and started
+  k8s_facts:
+    api_version: v1
+    kind: BuildConfig
+    namespace: pipeline-example
+    label_selectors:
+      - app = pipeline
+  register: buildconfig
+  until: buildconfig
+          and (buildconfig.resources | length > 0)
+  retries: 10
+  delay: 5

--- a/roles/pipeline/pipeline_example/tasks/main.yml
+++ b/roles/pipeline/pipeline_example/tasks/main.yml
@@ -6,18 +6,8 @@
         state: present
         definition: "{{ lookup('file', 'install-pipeline-example.yml')}}"
 
-    - name: Checking the build is created and started
-      k8s_facts:
-        api_version: v1
-        kind: BuildConfig
-        namespace: pipeline-example
-        label_selectors:
-          - app = pipeline
-      register: buildconfig
-      until: buildconfig
-             and (buildconfig.resources | length > 0)
-      retries: 10
-      delay: 5
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create a backup
   when: with_backup
@@ -33,15 +23,5 @@
       include_role:
         name: restore
 
-- name: Checking the build is restored
-  k8s_facts:
-    api_version: v1
-    kind: BuildConfig
-    namespace: pipeline-example
-    label_selectors:
-      - app = pipeline
-  register: buildconfig
-  until: buildconfig
-         and (buildconfig.resources | length > 0)
-  retries: 10
-  delay: 5
+    - name: Check resource presence
+      include: check.yml

--- a/roles/pod/hello-pod/tasks/check.yml
+++ b/roles/pod/hello-pod/tasks/check.yml
@@ -1,0 +1,9 @@
+- name: Wait for pod to run
+  k8s_facts:
+    kind: Pod
+    namespace: hello-pod
+    label_selectors: "name=hello-openshift"
+  register: pod
+  until: pod.get("resources", []) and pod.resources[0].get("status", {}).get("phase", "") == "Running"
+  retries: 20
+  delay: 10

--- a/roles/pod/hello-pod/tasks/main.yml
+++ b/roles/pod/hello-pod/tasks/main.yml
@@ -29,17 +29,8 @@
             - name: hello-openshift
               image: openshift/hello-openshift
 
-    - name: Wait for pod to run
-      k8s_facts:
-        kind: Pod
-        namespace: hello-pod
-        label_selectors: "name=hello-openshift"
-      register: pod
-      until:  pod.get("resources", [])
-              and pod.resources[0].get("status", {}).get("phase", "")
-              == "Running"
-      retries: 20
-      delay: 10
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create a backup
   when: with_backup
@@ -55,12 +46,5 @@
       include_role:
         name: restore
 
-    - name: Wait for pod to run
-      k8s_facts:
-        kind: Pod
-        namespace: hello-pod
-        label_selectors: "name=hello-openshift"
-      register: pod
-      until: pod.get("resources", []) and pod.resources[0].get("status", {}).get("phase", "") == "Running"
-      retries: 20
-      delay: 10
+    - name: Check resource presence
+      include: check.yml

--- a/roles/pvc/mysql_pvc/tasks/check.yml
+++ b/roles/pvc/mysql_pvc/tasks/check.yml
@@ -1,0 +1,19 @@
+- name: Wait for mysql with pvc deployment
+  k8s_facts:
+    kind: Pod
+    namespace: mysql-persistent
+    label_selectors: "deployment=mysql-1"
+  register: pod
+  until: pod.get("resources", []) and pod.resources[0].get("status", {}).get("phase", "") == "Running"
+  retries: 10
+  delay: 15
+
+- name: Check if volume is restored and bound
+  k8s_facts:
+    kind: PersistentVolumeClaim
+    namespace: mysql-persistent
+    label_selectors: "app=mysql"
+  register: volume
+  until: volume.get("resources", []) and volume.get("status", {}).get("phase", "") == "Bound"
+  retries: 10
+  delay: 15

--- a/roles/rbac/basic_sa_with_role/tasks/check.yml
+++ b/roles/rbac/basic_sa_with_role/tasks/check.yml
@@ -1,0 +1,32 @@
+- name: Wait 2 minutes for service account to appear
+  k8s_facts:
+    api_version: v1
+    kind: ServiceAccount
+    namespace: basic-sa-role
+    name: basic-sa
+  register: service_account
+  until: service_account and (service_account.resources | length > 0)
+  retries: 10
+  delay: 10
+
+- name: Wait 2 minutes for role to appear
+  k8s_facts:
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: Role
+    namespace: basic-sa-role
+    name: basic-role
+  register: role
+  until: role and (role.resources | length > 0)
+  retries: 10
+  delay: 10
+
+- name: Wait 2 minutes for role binding to appear
+  k8s_facts:
+    api_version: rbac.authorization.k8s.io/v1beta1
+    kind: RoleBinding
+    namespace: basic-sa-role
+    name: basic-role-binding
+  register: role_binding
+  until: role_binding and (role_binding.resources | length > 0)
+  retries: 10
+  delay: 10

--- a/roles/rbac/basic_sa_with_role/tasks/main.yml
+++ b/roles/rbac/basic_sa_with_role/tasks/main.yml
@@ -5,6 +5,9 @@
         state: present
         definition: "{{ lookup('file', 'basic-sa-role-template.yml')}}"
 
+    - name: Check resource presence
+      include: check.yml
+
 - name: Create backup
   when: with_backup
   block:
@@ -19,35 +22,5 @@
       include_role:
         name: restore
 
-    - name: Wait 2 minutes for service account to appear
-      k8s_facts:
-        api_version: v1
-        kind: ServiceAccount
-        namespace: basic-sa-role
-        name: basic-sa
-      register: service_account
-      until: service_account and (service_account.resources | length > 0)
-      retries: 10
-      delay: 10
-
-    - name: Wait 2 minutes for role to appear
-      k8s_facts:
-        api_version: rbac.authorization.k8s.io/v1beta1
-        kind: Role
-        namespace: basic-sa-role
-        name: basic-role
-      register: role
-      until: role and (role.resources | length > 0)
-      retries: 10
-      delay: 10
-
-    - name: Wait 2 minutes for role binding to appear
-      k8s_facts:
-        api_version: rbac.authorization.k8s.io/v1beta1
-        kind: RoleBinding
-        namespace: basic-sa-role
-        name: basic-role-binding
-      register: role_binding
-      until: role_binding and (role_binding.resources | length > 0)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml

--- a/roles/route/route_example/tasks/check.yml
+++ b/roles/route/route_example/tasks/check.yml
@@ -1,0 +1,10 @@
+- name: Check route presence
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: route-example
+    name: route-one
+  register: route
+  until: route.resources | length > 0
+  retries: 10
+  delay: 3

--- a/roles/route/route_example/tasks/main.yml
+++ b/roles/route/route_example/tasks/main.yml
@@ -6,16 +6,8 @@
         state: present
         definition: "{{ lookup('file', 'base.yml')}}"
 
-    - name: Checking the route before backup
-      k8s_facts:
-        api_version: route.openshift.io/v1
-        kind: Route
-        namespace: route-example
-        name: route-one
-      register: route
-      until: route.resources | length > 0
-      retries: 10
-      delay: 3
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create route and backup
   when: with_backup
@@ -31,13 +23,5 @@
       include_role:
         name: restore
 
-    - name: Checking the route after restore
-      k8s_facts:
-        api_version: route.openshift.io/v1
-        kind: Route
-        namespace: route-example
-        name: route-one
-      register: route
-      until: route.resources | length > 0
-      retries: 10
-      delay: 3
+    - name: Check resource presence
+      include: check.yml

--- a/roles/service/basic-service/tasks/check.yml
+++ b/roles/service/basic-service/tasks/check.yml
@@ -1,0 +1,22 @@
+- name: Wait 1 minute for services become available
+  k8s_facts:
+    kind: Service
+    api_version: v1
+    namespace: service-example
+    label_selectors: "name=my-service"
+  register: deploy
+  until: deploy.get("resources", []) and deploy.resources | length == 5
+  retries: 12
+  delay: 5
+
+- name: Wait 2 minute for deployment
+  k8s_facts:
+    kind: Deployment
+    api_version: v1
+    namespace: service-example
+    label_selectors: "name=my-service"
+  register: deploy
+  until:  deploy.get("resources", [])
+          and deploy.resources[0].get('status', {}).get('availableReplicas', -1) == deploy.resources[0].get("spec", {}).get('replicas', -2)
+  retries: 24
+  delay: 5

--- a/roles/service/basic-service/tasks/main.yml
+++ b/roles/service/basic-service/tasks/main.yml
@@ -6,28 +6,8 @@
         state: present
         definition: "{{ lookup('file', 'service-template.yml') }}"
 
-    - name: Wait 1 minute for services become available
-      k8s_facts:
-        kind: Service
-        api_version: v1
-        namespace: service-example
-        label_selectors: "name=my-service"
-      register: deploy
-      until: deploy.get("resources", []) and deploy.resources | length == 5
-      retries: 12
-      delay: 5
-
-    - name: Wait 2 minute for deployment
-      k8s_facts:
-        kind: Deployment
-        api_version: v1
-        namespace: service-example
-        label_selectors: "name=my-service"
-      register: deploy
-      until:  deploy.get("resources", [])
-              and deploy.resources[0].get('status', {}).get('availableReplicas', -1) == deploy.resources[0].get("spec", {}).get('replicas', -2)
-      retries: 24
-      delay: 5
+    - name: Check resource presence
+      include: check.yml
 
 - name: Create a backup
   when: with_backup
@@ -43,12 +23,5 @@
       include_role:
         name: restore
 
-    - name: Wait 2 minutes for service to appear
-      k8s_facts:
-        api_version: v1
-        kind: Service
-        namespace: service-example
-      register: svc
-      until: svc and (svc.resources | length == 5)
-      retries: 10
-      delay: 10
+    - name: Check resource presence
+      include: check.yml


### PR DESCRIPTION
I decided to move resource presence checks to a separate task, so we could avoid unnecessary duplications.