### PR TITLE
Network policy tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ We need to keep track of supported and unsupported test cases.
   - Route - ```route```
   - CRD - ```crd```
   - Service - ```service```
+  - NetworkPolicy - ```net-policy``` - prerequisites needed
   - Pipeline - ```pipeline```
 
 * Tests cases that are expected to fail:
 
   - S2I - ```cakephp```
   - PVC - ```mysql-pvc```
+
+* Test cases prerequisites
+
+  - NetworkPolicy - ```net-policy\net-policy-extended```
+    - OCP-3: ```networkPluginName: redhat/openshift-ovs-networkpolicy``` should be specified in `/etc/origin/master/master-config.yaml`, or better create new cluster under upshift with `openshift` bundle and `os_sdn_network_plugin_name` set to `ovs-networkpolicy`.
+    - OCP-4: comes with default `Networkpolicy` plugin, but for editing use `oc edit networkconfig` and configure as stated in the example https://github.com/openshift/cluster-network-operator#configuring-openshiftsdn

--- a/all.yml
+++ b/all.yml
@@ -4,6 +4,7 @@
     with_backup: false
     with_restore: false
   roles:
+    - net-policy/net-policy-extended
     - rbac/basic_sa_with_role
     - pvc/mysql_pvc
     - deployment/nginx_deployment

--- a/net-policy.yml
+++ b/net-policy.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  vars:
+    with_backup: true
+    with_restore: true
+    prompt_login: "{{ lookup('ENV', 'PROMPT_LOGIN') }}"
+  roles:
+  - login_ocp
+  - net-policy/net-policy-extended

--- a/roles/net-policy/net-policy-extended/defaults/main.yml
+++ b/roles/net-policy/net-policy-extended/defaults/main.yml
@@ -1,0 +1,7 @@
+backup_name: net-pol-backup
+backup_label: net-policy
+restore_name: net-pol-restore
+namespaces_to_delete:
+  - net-pr-1
+  - net-pr-2
+  - net-ext

--- a/roles/net-policy/net-policy-extended/files/net-pol-nets-template.yml
+++ b/roles/net-policy/net-policy-extended/files/net-pol-nets-template.yml
@@ -1,0 +1,46 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-same-namespace
+  namespace: net-pr-2
+  labels:
+    test: net-policy
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          group: net-group
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-all-to-httpd-ex
+  namespace: net-pr-1
+  labels:
+    test: net-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: httpd-ex
+  ingress:
+  - {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: foo-deny-external-egress
+  namespace: net-ext
+  labels:
+    test: net-policy
+spec:
+  podSelector:
+    matchLabels:
+      outbound: deny
+  policyTypes:
+  - Egress
+  egress: []

--- a/roles/net-policy/net-policy-extended/files/net-pol-template.yml
+++ b/roles/net-policy/net-policy-extended/files/net-pol-template.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: net-pr-1
+  labels:
+    app: net-policy
+    group: net-group
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: net-pr-2
+  labels:
+    app: net-policy
+    group: net-group
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: net-ext
+  labels:
+    app: net-policy
+

--- a/roles/net-policy/net-policy-extended/tasks/check.yml
+++ b/roles/net-policy/net-policy-extended/tasks/check.yml
@@ -1,0 +1,12 @@
+- name: Wait for pod running on second namespace
+  k8s_facts:
+    api_version: v1
+    kind: Pod
+    namespace: net-pr-2
+    name: httpd-ex
+  register: pod
+  until:  pod.get("resources", [])
+          and pod.resources[0].get("status", {}).get("phase", "") ==
+          "Running"
+  retries: 30
+  delay: 10

--- a/roles/net-policy/net-policy-extended/tasks/main.yml
+++ b/roles/net-policy/net-policy-extended/tasks/main.yml
@@ -1,0 +1,45 @@
+- name: Create resources
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'net-pol-template.yml') }}"
+
+- name: Create pod separately
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        namespace: net-pr-2
+        name: httpd-ex
+        labels:
+          app: net-policy
+      spec:
+        containers:
+          - name: hello-openshift
+            image: centos/httpd-24-centos7
+
+- name: Test resources
+  include: check.yml
+
+- name: Create resources
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'net-pol-nets-template.yml') }}"
+
+- name: Create backup
+  when: with_backup
+  block:
+    - name: Create backup
+      include_role:
+        name: backup
+
+- name: Restore service
+  when: with_restore
+  block:
+    - name: Start restoring 
+      include_role:
+        name: restore
+
+- name: Test resources
+  include: check.yml


### PR DESCRIPTION
This test data leverage NetworkPolicy resources.
Created resources are not expected to work properly on OCP-3 cluster, until you will change the network plugin to ovs-networkpolicy. Steps for doing this are explained in readme.