### PR TITLE
Added annotation to make restic backup the pv, moded with_data.

### DIFF
--- a/roles/pvc/mysql_pvc/files/mysql-persistent-template.yml
+++ b/roles/pvc/mysql_pvc/files/mysql-persistent-template.yml
@@ -68,6 +68,9 @@ spec:
     metadata:
       labels:
         name: mysql
+        app: mysql
+      annotations:
+        backup.velero.io/backup-volumes: mysql-data
     spec:
       containers:
       - env:

--- a/roles/pvc/mysql_pvc/tasks/main.yml
+++ b/roles/pvc/mysql_pvc/tasks/main.yml
@@ -9,30 +9,32 @@
       include: check.yml
 
     - name: Populate the database with test data
+      block:
+        - name: Populating db with data
+          vars:
+            pod_name: "{{ pod.resources[0].get('metadata', {}).get('name', '') }}"
+            src: "{{ playbook_dir }}/roles/pvc/mysql_pvc/files/"
+            dest: /opt/app-root/src
+          shell: |
+                  oc rsync {{ src }} {{ pod_name }}:{{ dest }} --exclude=* --include=*.sql
+                  oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "mysql -uMYSQL_USER -pMYSQL_PASSWORD MYSQL_DATABASE < data.sql"
+        - name: Wait 1 munite for MySQL service to Start
+          pause:
+            minutes: 1
+
+        - name: Flush tables with read lock before backup
+          vars:
+            pod_name: "{{ pod.resources[0].get('metadata', {}).get('name', '') }}"
+          shell: |
+                  oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "echo 'FLUSH TABLES WITH READ LOCK;' > lock.sql"
+                  oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "mysql -u root < lock.sql"
       when: with_data
-      vars:
-        pod_name: "{{ pod.resources[0].get('metadata', {}).get('name', '') }}"
-        src: "{{ playbook_dir }}/roles/pvc/mysql_pvc/files/"
-        dest: /opt/app-root/src
-      shell: |
-              oc rsync {{ src }} {{ pod_name }}:{{ dest }} --exclude=* --include=*.sql
-              oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "mysql -uMYSQL_USER -pMYSQL_PASSWORD MYSQL_DATABASE < data.sql"
 
   when: with_resources
 
 - name: Create a backup
   when: with_backup
   block:
-    - name: Wait 1 munite for MySQL service to Start
-      pause:
-        minutes: 1
-
-    - name: Flush tables with read lock before backup
-      vars:
-        pod_name: "{{ pod.resources[0].get('metadata', {}).get('name', '') }}"
-      shell: |
-              oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "echo 'FLUSH TABLES WITH READ LOCK;' > lock.sql"
-              oc exec -n mysql-persistent {{ pod_name }} -- /bin/bash -c "mysql -u root < lock.sql"
 
     - name: Create backup
       include_role:


### PR DESCRIPTION
Now velero should be able to backup the PV which is attached to the PVC specified in pod definition.
```
      annotations:
        backup.velero.io/backup-volumes: mysql-data
```
Data load is now encapsulated.